### PR TITLE
fix where clause handling in builder generation

### DIFF
--- a/confik-macros/src/lib.rs
+++ b/confik-macros/src/lib.rs
@@ -682,11 +682,13 @@ impl RootImplementer {
             None
         };
 
+        let (_impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
         quote_spanned! { target_name.span() =>
-            #[derive(::std::fmt::Debug, ::std::default::Default, ::confik::__exports::__serde::Deserialize, #additional_derives )]
+            #[derive(::std::default::Default, ::confik::__exports::__serde::Deserialize, #additional_derives )]
             #[serde(crate = "::confik::__exports::__serde")]
             #forward_serde
-            #vis #enum_or_struct_token #builder_name #generics
+            #vis #enum_or_struct_token #builder_name #type_generics #where_clause
                 #bracketed_data
             #terminator
         }

--- a/confik-macros/tests/trybuild.rs
+++ b/confik-macros/tests/trybuild.rs
@@ -26,6 +26,7 @@ fn compile_macros() {
     t.pass("tests/trybuild/20-enum.rs");
     t.pass("tests/trybuild/21-field-from.rs");
     t.pass("tests/trybuild/22-dataless-types.rs");
+    t.pass("tests/trybuild/23-where-clause.rs");
 
     t.compile_fail("tests/trybuild/fail-default-parse.rs");
     t.compile_fail("tests/trybuild/fail-default-invalid-expr.rs");

--- a/confik-macros/tests/trybuild/23-where-clause.rs
+++ b/confik-macros/tests/trybuild/23-where-clause.rs
@@ -1,0 +1,28 @@
+use confik::Configuration;
+use serde::de::DeserializeOwned;
+
+trait MyTrait {
+    type Config: Configuration;
+}
+
+#[derive(Configuration)]
+struct EmptyConfig;
+
+impl MyTrait for () {
+    type Config = EmptyConfig;
+}
+
+#[derive(Configuration)]
+#[confik(forward_serde(bound = "C: MyTrait + DeserializeOwned"))]
+struct Config<C>
+where
+    C: MyTrait + Default + DeserializeOwned,
+{
+    sub_config: <C as MyTrait>::Config,
+}
+
+fn main() {
+    Config::<()>::builder()
+        .try_build()
+        .expect("No configuration needed");
+}

--- a/confik/CHANGELOG.md
+++ b/confik/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Remove `Debug` implementation from configuration builders
+- Remove `Debug` implementation requirement for lead configuration
+- Fix `Configuration` derive with `where` clauses
+
 ## 0.10.1
 
 - Implement `Configuration` for [`secrecy::SecretString`](https://docs.rs/secrecy/0.8/secrecy/type.SecretString.html). This type is always considered a secret, and can only be loaded from `Source`s which `.allow_secrets()`.

--- a/confik/src/lib.rs
+++ b/confik/src/lib.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, ops::Not};
 
 #[doc(hidden)]
 pub use confik_macros::*;
+use serde::de::DeserializeOwned;
 
 use crate::{path::Path, sources::DynSource};
 
@@ -129,7 +130,7 @@ pub trait Configuration: Sized {
 /// missing is not an error.
 /// For trivial cases, this is solved by using an `Option<Configuration>`.
 /// See the worked example on [`Configuration`].
-pub trait ConfigurationBuilder: Default + serde::de::DeserializeOwned {
+pub trait ConfigurationBuilder: Default + DeserializeOwned {
     /// The target that will be converted into. See [`Configuration`].
     type Target;
 
@@ -156,7 +157,7 @@ pub trait ConfigurationBuilder: Default + serde::de::DeserializeOwned {
 /// the worked example on [`Configuration`].
 impl<T> ConfigurationBuilder for Option<T>
 where
-    T: serde::de::DeserializeOwned + Configuration,
+    T: DeserializeOwned + Configuration,
 {
     type Target = T;
 


### PR DESCRIPTION
`Debug` is gone despite being a breaking change because:
- I'm pretty sure it's a holdover and not actually needed
- It complicates the `where` clause handling