### PR TITLE
feat!: Optional sources

### DIFF
--- a/confik/CHANGELOG.md
+++ b/confik/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Optional `Source`s.
+- `FileSource` can be set as optional.
+
 ## 0.11.7
 
 - Implement `Configuration` for [`bigdecimal::BigDecimal`](https://docs.rs/bigdecimal/0.4/bigdecimal/struct.BigDecimal.html).

--- a/confik/Cargo.toml
+++ b/confik/Cargo.toml
@@ -60,6 +60,7 @@ rust_decimal = { version = "1", optional = true, features = ["serde"] }
 secrecy = { version = "0.8", optional = true, features = ["serde"] }
 url = { version = "2", optional = true, features = ["serde"] }
 uuid = { version = "1", optional = true, features = ["serde"] }
+log = "0.4"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/confik/src/sources/env_source.rs
+++ b/confik/src/sources/env_source.rs
@@ -80,8 +80,12 @@ impl<'a> Source for EnvSource<'a> {
         self.allow_secrets
     }
 
-    fn provide<T: ConfigurationBuilder>(&self) -> Result<T, Box<dyn Error + Sync + Send>> {
-        Ok(self.config.build_from_env()?)
+    fn provide<T: ConfigurationBuilder>(&self) -> Option<Result<T, Box<dyn Error + Sync + Send>>> {
+        let configuration = self.config.build_from_env();
+        match configuration {
+            Ok(configuration) => Some(Ok(configuration)),
+            Err(error) => Some(Err(Box::new(error))),
+        }
     }
 }
 

--- a/confik/src/sources/json_source.rs
+++ b/confik/src/sources/json_source.rs
@@ -30,8 +30,12 @@ impl<'a> Source for JsonSource<'a> {
         self.allow_secrets
     }
 
-    fn provide<T: ConfigurationBuilder>(&self) -> Result<T, Box<dyn Error + Sync + Send>> {
-        Ok(serde_json::from_str(&self.contents)?)
+    fn provide<T: ConfigurationBuilder>(&self) -> Option<Result<T, Box<dyn Error + Sync + Send>>> {
+        let configuration = serde_json::from_str(&self.contents);
+        match configuration {
+            Ok(configuration) => Some(Ok(configuration)),
+            Err(error) => Some(Err(Box::new(error))),
+        }
     }
 }
 

--- a/confik/src/sources/mod.rs
+++ b/confik/src/sources/mod.rs
@@ -13,12 +13,13 @@ pub trait Source: Debug {
     }
 
     /// Attempts to provide a partial configuration object from this source.
-    fn provide<T: ConfigurationBuilder>(&self) -> Result<T, Box<dyn Error + Sync + Send>>;
+    /// If the source is optional and not present, this method should return `None`.
+    fn provide<T: ConfigurationBuilder>(&self) -> Option<Result<T, Box<dyn Error + Sync + Send>>>;
 }
 
 pub(crate) trait DynSource<T>: Debug {
     fn allows_secrets(&self) -> bool;
-    fn provide(&self) -> Result<T, Box<dyn Error + Sync + Send>>;
+    fn provide(&self) -> Option<Result<T, Box<dyn Error + Sync + Send>>>;
 }
 
 impl<S, T> DynSource<T> for S
@@ -30,7 +31,7 @@ where
         <S as Source>::allows_secrets(self)
     }
 
-    fn provide(&self) -> Result<T, Box<dyn Error + Sync + Send>> {
+    fn provide(&self) -> Option<Result<T, Box<dyn Error + Sync + Send>>> {
         <S as Source>::provide(self)
     }
 }
@@ -46,8 +47,8 @@ where
         true
     }
 
-    fn provide(&self) -> Result<T, Box<dyn Error + Sync + Send>> {
-        Ok(T::default())
+    fn provide(&self) -> Option<Result<T, Box<dyn Error + Sync + Send>>> {
+        Some(Ok(T::default()))
     }
 }
 

--- a/confik/src/sources/toml_source.rs
+++ b/confik/src/sources/toml_source.rs
@@ -34,8 +34,12 @@ impl<'a> Source for TomlSource<'a> {
         self.allow_secrets
     }
 
-    fn provide<T: ConfigurationBuilder>(&self) -> Result<T, Box<dyn Error + Sync + Send>> {
-        Ok(toml::from_str(&self.contents)?)
+    fn provide<T: ConfigurationBuilder>(&self) -> Option<Result<T, Box<dyn Error + Sync + Send>>> {
+        let configuration = toml::from_str(&self.contents);
+        match configuration {
+            Ok(configuration) => Some(Ok(configuration)),
+            Err(error) => Some(Err(Box::new(error))),
+        }
     }
 }
 


### PR DESCRIPTION
Files and possibly other types of sources may not be present all the time. Some sources may only be present in specific environments, and fallback to a lower-priority source/default configuration is an explicitly chosen strategy. To support this scenario, sources are no longer required to provide a result. When `None` is returned, the source is seen as not present and **ignored**. As not all sources are expected to be optional, this is source-specific. Each source manages optional presence on its own.

Marked as a breaking change, because the `Source` trait is `pub`.

This MR is a proposal. I'm fully aware it may not fit this crate's objectives, or be unfit any other way. I'm happy to make changes should any be needed.

## Other thoughts and ideas

- Conditional source presence. Set a criteria to enforce which environments MUST provide it. If the criteria is based on configuration, its presence would have to be evaluated after configuration deserialization, making it much more difficult.
- Instead of making output of the `Source::provide` functional optional, an more restricted Error type could be used and tested for a specific error kind in order to ignore a missing resource. Main advantage is not having to deal with the `Optional` wrapper, making it easier to use the `?` operator on result. Also, more centralized logging.
- A question I asked myself: Can this be considered an anti-pattern ? I'd say no - it's ok to expect `prod` configuration with higher priority than local/default configuration to be placed elsewhere than the local/default configuration. WDYT ?