### PR TITLE
Non specific attributes

### DIFF
--- a/confik-macros/src/lib.rs
+++ b/confik-macros/src/lib.rs
@@ -624,10 +624,10 @@ struct RootImplementer {
     vis: Visibility,
 
     /// Optional attributes to forward to the builder struct/enum.
+    ///
+    /// This can be serde attributes e.g. `#[confik(forward(serde(default)))]` but also others like
+    /// `#[confik(forward(derive(Hash)))]`
     forward: Option<Forward>,
-
-    /// Derives needed by the builder, e.g. `Hash`.
-    derive: Option<Derive>,
 }
 
 impl RootImplementer {
@@ -666,7 +666,6 @@ impl RootImplementer {
             generics,
             vis,
             forward,
-            derive: additional_derives,
             ..
         } = self;
 
@@ -725,7 +724,7 @@ impl RootImplementer {
         let (_impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
         Ok(quote_spanned! { target_name.span() =>
-            #[derive(::std::default::Default, ::confik::__exports::__serde::Deserialize, #additional_derives )]
+            #[derive(::std::default::Default, ::confik::__exports::__serde::Deserialize)]
             #[serde(crate = "::confik::__exports::__serde")]
             #forward
             #vis #enum_or_struct_token #builder_name #type_generics #where_clause

--- a/confik-macros/tests/trybuild.rs
+++ b/confik-macros/tests/trybuild.rs
@@ -34,7 +34,7 @@ fn compile_macros() {
     t.compile_fail("tests/trybuild/fail-default-invalid-expr.rs");
     t.compile_fail("tests/trybuild/fail-config-name-value.rs");
     t.compile_fail("tests/trybuild/fail-secret-extra-attr.rs");
-    t.compile_fail("tests/trybuild/fail-derive-literal.rs");
+    t.compile_fail("tests/trybuild/fail-forward-literal.rs");
     t.compile_fail("tests/trybuild/fail-field-from-unknown-type.rs");
     t.compile_fail("tests/trybuild/fail-uncreatable-type.rs");
     t.compile_fail("tests/trybuild/fail-not-a-type.rs");

--- a/confik-macros/tests/trybuild/19-derive.rs
+++ b/confik-macros/tests/trybuild/19-derive.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashSet};
 use confik::Configuration;
 
 #[derive(Configuration)]
-#[confik(derive(::std::hash::Hash, std::cmp::Ord, PartialOrd, Eq, PartialEq, Clone))]
+#[confik(forward(derive(::std::hash::Hash, std::cmp::Ord, PartialOrd, Eq, PartialEq, Clone)))]
 struct Target {
     item: usize,
 }

--- a/confik-macros/tests/trybuild/23-where-clause.rs
+++ b/confik-macros/tests/trybuild/23-where-clause.rs
@@ -13,7 +13,7 @@ impl MyTrait for () {
 }
 
 #[derive(Configuration)]
-#[confik(forward_serde(bound = "C: MyTrait + DeserializeOwned"))]
+#[confik(forward(serde(bound = "C: MyTrait + DeserializeOwned")))]
 struct Config<C>
 where
     C: MyTrait + Default + DeserializeOwned,

--- a/confik-macros/tests/trybuild/fail-derive-literal.stderr
+++ b/confik-macros/tests/trybuild/fail-derive-literal.stderr
@@ -1,5 +1,0 @@
-error: Expected a path to a derivable trait, got Lit(Lit::Str { token: "hello world" })
- --> tests/trybuild/fail-derive-literal.rs:2:17
-  |
-2 | #[confik(derive("hello world"))]
-  |                 ^^^^^^^^^^^^^

--- a/confik-macros/tests/trybuild/fail-forward-literal.rs
+++ b/confik-macros/tests/trybuild/fail-forward-literal.rs
@@ -1,5 +1,5 @@
 #[derive(confik::Configuration)]
-#[confik(derive("hello world"))]
+#[confik(forward("hello world"))]
 struct A;
 
 fn main() {}

--- a/confik-macros/tests/trybuild/fail-forward-literal.stderr
+++ b/confik-macros/tests/trybuild/fail-forward-literal.stderr
@@ -1,0 +1,17 @@
+error: expected identifier, found `"hello world"`
+ --> tests/trybuild/fail-forward-literal.rs:2:18
+  |
+2 | #[confik(forward("hello world"))]
+  |                  ^^^^^^^^^^^^^ expected identifier
+
+error: proc-macro derive produced unparsable tokens
+ --> tests/trybuild/fail-forward-literal.rs:1:10
+  |
+1 | #[derive(confik::Configuration)]
+  |          ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `AConfigBuilder` in this scope
+ --> tests/trybuild/fail-forward-literal.rs:3:8
+  |
+3 | struct A;
+  |        ^ not found in this scope

--- a/confik/CHANGELOG.md
+++ b/confik/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 - Implement `Configuration` for [`js_option::JsOption`](https://docs.rs/js_option/0.1.1/js_option/enum.JsOption.html)
+- Add a new `confik(forward(...))` attribute. As well as allowing for forwarding general attributes to the builder, this:
+  - Replaces `confik(forward_serde(...))`. E.g.
+    ```rust
+    #[derive(Configuration)]
+    struct Config {
+      #[confik(forward(serde(default)))]
+      num: usize,
+    }
+    ```
 
 ## 0.13.0
 

--- a/confik/CHANGELOG.md
+++ b/confik/CHANGELOG.md
@@ -12,6 +12,12 @@
       num: usize,
     }
     ```
+  - Replaces `confik(derive(...))`. E.g.
+    ```rust
+    #[derive(Configuration)]
+    #[confik(forward(derive(Hash)))]
+    struct Config(usize);
+    ```
 
 ## 0.13.0
 

--- a/confik/examples/derives.rs
+++ b/confik/examples/derives.rs
@@ -9,7 +9,7 @@ struct Config {
 }
 
 #[derive(Debug, Configuration, Hash, Eq, PartialEq)]
-#[confik(derive(Hash, Eq, PartialEq))]
+#[confik(forward(derive(Hash, Eq, PartialEq)))]
 struct Value {
     inner: String,
 }

--- a/confik/src/common.rs
+++ b/confik/src/common.rs
@@ -6,7 +6,7 @@ use crate::{Configuration, MissingValue};
 
 /// The database type, used to determine the connection string format
 #[derive(Debug, Clone, PartialEq, Eq, Configuration)]
-#[confik(forward_serde(rename_all = "lowercase"))]
+#[confik(forward(serde(rename_all = "lowercase")))]
 enum DatabaseKind {
     Mysql,
     Postgres,

--- a/confik/src/lib.md
+++ b/confik/src/lib.md
@@ -76,19 +76,21 @@ struct Config {
 }
 ```
 
-### Forwarding Attributes To `Deserialize`
+### Forwarding Attributes
 
-The serde attributes used for customizing a `Deserialize` derive typically are achieved by adding `#[confik(forward_serde(...))` attributes.
+The serde attributes used for customizing a `Deserialize` derive typically are achieved by adding `#[confik(forward(serde(...)))]` attributes.
 
 For example:
 
 ```
 #[derive(confik::Configuration)]
 struct Config {
-    #[confik(forward_serde(rename = "other_data"))]
+    #[confik(forward(serde(rename = "other_data")))]
     data: usize,
 }
 ```
+
+This can also be used for non-serde attributes, but this is less commonly needed.
 
 ### Defaults
 

--- a/confik/src/lib.md
+++ b/confik/src/lib.md
@@ -69,7 +69,7 @@ If a secret is found in an insecure source, an error will be returned. You can o
 
 The derive macro is called `Configuration` and is used as normal:
 
-```
+```rust
 #[derive(confik::Configuration)]
 struct Config {
     data: usize,
@@ -78,19 +78,37 @@ struct Config {
 
 ### Forwarding Attributes
 
-The serde attributes used for customizing a `Deserialize` derive typically are achieved by adding `#[confik(forward(serde(...)))]` attributes.
+This allows forwarding any kind of attribute on to the builder.
+
+#### Serde
+
+The serde attributes used for customizing a `Deserialize` derive are achieved by adding `#[confik(forward(serde(...)))]` attributes.
 
 For example:
 
+```rust
+# use confik::Configuration;
+#[derive(Configuration, Debug, PartialEq, Eq)]
+struct Field {
+    #[confik(forward(serde(rename = "other_name")))]
+    field1: usize,
+}
 ```
-#[derive(confik::Configuration)]
-struct Config {
-    #[confik(forward(serde(rename = "other_data")))]
-    data: usize,
+#### Derives
+
+If you need additional derives for your type, these can be added via `#[confik(forward(derive...))]` attributes.
+
+For example:
+
+```rust
+# use confik::Configuration;
+#[derive(Debug, Configuration, Hash, Eq, PartialEq)]
+#[confik(forward(derive(Hash, Eq, PartialEq)))]
+struct Value {
+    inner: String,
 }
 ```
 
-This can also be used for non-serde attributes, but this is less commonly needed.
 
 ### Defaults
 
@@ -98,7 +116,7 @@ Defaults are specified on a per-field basis.
 
 - Defaults only apply if no data has been read for that field. E.g., if `data` in the below example has one value read in, it will return an error.
 
-  ```
+  ```rust
   # #[cfg(feature = "toml")]
   # {
   use confik::{Configuration, TomlSource};
@@ -150,7 +168,7 @@ Defaults are specified on a per-field basis.
 
 - Defaults can be given by any rust expression, and have [`Into::into`] run over them. E.g.,
 
-  ```
+  ```rust
   const DEFAULT_VALUE: u8 = 4;
 
   #[derive(confik::Configuration)]
@@ -166,7 +184,7 @@ Defaults are specified on a per-field basis.
 
 - Alternatively, a default without a given value called [`Default::default`]. E.g.,
 
-  ```
+  ```rust
   use confik::{Configuration};
 
   #[derive(Configuration)]
@@ -195,7 +213,7 @@ This crate provides implementations of [`Configuration`] for a number of `std` t
 
 If there's another foreign type used in your config, then you will not be able to implement [`Configuration`] for it. Instead any type that implements [`Into`] or [`TryInto`] can be used.
 
-```
+```rust
 struct ForeignType {
     data: usize,
 }

--- a/confik/tests/forward/mod.rs
+++ b/confik/tests/forward/mod.rs
@@ -1,22 +1,22 @@
 use confik::Configuration;
 
 #[derive(Configuration, Debug, PartialEq, Eq)]
-#[confik(forward_serde(rename_all = "UPPERCASE"))]
+#[confik(forward(serde(rename_all = "UPPERCASE")))]
 struct Container {
     field: usize,
 }
 
 #[derive(Configuration, Debug, PartialEq, Eq)]
 struct Inner {
-    #[confik(forward_serde(rename = "outer"))]
+    #[confik(forward(serde(rename = "outer")))]
     inner: usize,
 }
 
 #[derive(Configuration, Debug, PartialEq, Eq)]
 struct Field {
-    #[confik(forward_serde(rename = "other_name"))]
+    #[confik(forward(serde(rename = "other_name")))]
     field1: usize,
-    #[confik(forward_serde(flatten))]
+    #[confik(forward(serde(flatten)))]
     field2: Inner,
 }
 
@@ -25,7 +25,7 @@ enum Clothes {
     Hat,
     // Put some data in to force use of a custom builder
     Scarf(usize),
-    #[confik(forward_serde(alias = "Gloves", alias = "SomethingElse"))]
+    #[confik(forward(serde(alias = "Gloves", alias = "SomethingElse")))]
     Other,
 }
 

--- a/confik/tests/keyed_containers/mod.rs
+++ b/confik/tests/keyed_containers/mod.rs
@@ -3,7 +3,7 @@ macro_rules! create_tests_for {
         use confik::Configuration;
 
         #[derive(Debug, Configuration, PartialEq, Eq, Hash, Ord, PartialOrd)]
-        #[confik(derive(Hash, PartialEq, Eq, Ord, PartialOrd))]
+        #[confik(forward(derive(Hash, PartialEq, Eq, Ord, PartialOrd)))]
         struct TwoVals {
             first: usize,
             second: usize,

--- a/confik/tests/main.rs
+++ b/confik/tests/main.rs
@@ -3,11 +3,11 @@ mod array;
 mod common;
 mod complex_enums;
 mod defaulting_containers;
+mod forward;
 mod keyed_containers;
 mod option_builder;
 mod secret;
 mod secret_option;
-mod serde_forward;
 mod singly_nested_tests;
 mod third_party;
 mod unkeyed_containers;
@@ -84,7 +84,7 @@ mod toml {
     fn from_humantime() {
         #[derive(Debug, PartialEq, Eq, Configuration)]
         struct Config {
-            #[confik(forward_serde(with = "humantime_serde"))]
+            #[confik(forward(serde(with = "humantime_serde")))]
             timeout: Duration,
         }
 

--- a/confik/tests/unkeyed_containers/mod.rs
+++ b/confik/tests/unkeyed_containers/mod.rs
@@ -3,7 +3,7 @@ macro_rules! create_tests_for {
         use confik::Configuration;
 
         #[derive(Debug, Configuration, PartialEq, Eq, Hash, Ord, PartialOrd)]
-        #[confik(derive(Hash, PartialEq, Eq, Ord, PartialOrd))]
+        #[confik(forward(derive(Hash, PartialEq, Eq, Ord, PartialOrd)))]
         struct TwoVals {
             first: usize,
             second: usize,


### PR DESCRIPTION
TBH a chunk of why I'm doing this is because I keep forgetting if it's `forward_serde` or `serde_forward`, but I also don't see any need for this to be `serde` specific, nor do we need separate handling for `derive` when they're both just forwarding on attributes.

There's also a small use-case here for deriving another trait and setting attributes for it.