### PR TITLE
Fix stable and MSRV CI failures

### DIFF
--- a/confik/tests/complex_enums/mod.rs
+++ b/confik/tests/complex_enums/mod.rs
@@ -1,6 +1,7 @@
+#![allow(dead_code)] // derived builders are unused without source features
+
 use confik::Configuration;
 
-#[allow(dead_code)] // unused in no-default-features cases
 #[derive(Configuration, Debug, PartialEq, Eq)]
 enum Target {
     Simple,
@@ -8,7 +9,6 @@ enum Target {
     Field { field1: usize, field2: usize },
 }
 
-#[allow(dead_code)] // unused in no-default-features cases
 #[derive(Configuration, Debug, PartialEq, Eq)]
 struct RootTarget {
     target: Target,

--- a/confik/tests/forward/mod.rs
+++ b/confik/tests/forward/mod.rs
@@ -1,20 +1,19 @@
+#![allow(dead_code)] // derived builders are unused without source features
+
 use confik::Configuration;
 
-#[allow(dead_code)] // unused in no-default-features cases
 #[derive(Configuration, Debug, PartialEq, Eq)]
 #[confik(forward(serde(rename_all = "UPPERCASE")))]
 struct Container {
     field: usize,
 }
 
-#[allow(dead_code)] // unused in no-default-features cases
 #[derive(Configuration, Debug, PartialEq, Eq)]
 struct Inner {
     #[confik(forward(serde(rename = "outer")))]
     inner: usize,
 }
 
-#[allow(dead_code)] // unused in no-default-features cases
 #[derive(Configuration, Debug, PartialEq, Eq)]
 struct Field {
     #[confik(forward(serde(rename = "other_name")))]
@@ -23,7 +22,6 @@ struct Field {
     field2: Inner,
 }
 
-#[allow(dead_code)] // unused in no-default-features cases
 #[derive(Debug, PartialEq, Eq, Configuration)]
 enum Clothes {
     Hat,
@@ -33,7 +31,6 @@ enum Clothes {
     Other,
 }
 
-#[allow(dead_code)] // unused in no-default-features cases
 #[derive(Configuration)]
 struct Cupboard {
     items: Vec<Clothes>,

--- a/confik/tests/keyed_containers/mod.rs
+++ b/confik/tests/keyed_containers/mod.rs
@@ -1,8 +1,9 @@
+#![allow(dead_code)] // derived builders are unused without source features
+
 macro_rules! create_tests_for {
     ($container:ty) => {
         use confik::Configuration;
 
-        #[allow(dead_code)] // unused in no-default-features cases
         #[derive(Debug, Configuration, PartialEq, Eq, Hash, Ord, PartialOrd)]
         #[confik(forward(derive(Hash, PartialEq, Eq, Ord, PartialOrd)))]
         struct TwoVals {
@@ -10,7 +11,6 @@ macro_rules! create_tests_for {
             second: usize,
         }
 
-        #[allow(dead_code)] // unused in no-default-features cases
         #[derive(Debug, Configuration, PartialEq, Eq)]
         struct Target {
             val: $container,

--- a/confik/tests/unkeyed_containers/mod.rs
+++ b/confik/tests/unkeyed_containers/mod.rs
@@ -1,8 +1,9 @@
+#![allow(dead_code)] // derived builders are unused without source features
+
 macro_rules! create_tests_for {
     ($container:ty) => {
         use confik::Configuration;
 
-        #[allow(dead_code)] // unused in no-default-features cases
         #[derive(Debug, Configuration, PartialEq, Eq, Hash, Ord, PartialOrd)]
         #[confik(forward(derive(Hash, PartialEq, Eq, Ord, PartialOrd)))]
         struct TwoVals {
@@ -10,7 +11,6 @@ macro_rules! create_tests_for {
             second: usize,
         }
 
-        #[allow(dead_code)] // unused in no-default-features cases
         #[derive(Debug, Configuration, PartialEq, Eq)]
         struct Target {
             val: $container,

--- a/justfile
+++ b/justfile
@@ -23,9 +23,12 @@ msrv_rustup := "+" + msrv
 # Downgrade dev-dependencies necessary to run MSRV checks/tests.
 [private]
 downgrade-for-msrv toolchain="":
+    cargo {{ toolchain }} update -p=trybuild --precise=1.0.116 # next ver: 1.85
     cargo {{ toolchain }} update -p=serde_with --precise=3.16.1 # next ver: 1.82
+    cargo {{ toolchain }} update -p=bytesize --precise=2.3.1 # next ver: 1.85
     cargo {{ toolchain }} update -p=uuid --precise=1.20.0 # next ver: 1.85
     cargo {{ toolchain }} update -p=getrandom@0.4 --precise=0.3.4 # next ver: 1.85
+    cargo {{ toolchain }} update -p=wasip2 --precise=1.0.1+wasi-0.2.4 # next ver: 1.87
     cargo {{ toolchain }} update -p=time --precise=0.3.45 # next ver: 1.88
     cargo {{ toolchain }} update -p=idna_adapter --precise=1.2.0 # next ver: 1.82
     cargo {{ toolchain }} update -p=proc-macro-crate --precise=3.4.0 # next ver: 1.82.0


### PR DESCRIPTION
## Summary

- allow dead code at feature-gated test-module scope so generated builders pass the stable warning-denied build
- extend the MSRV downgrade recipe with compatible `trybuild`, `bytesize`, and `wasip2` releases

## Root cause

Rust stable advanced to 1.97, which reports dead generated builder items that the existing item-level lint attributes did not cover.

The current lockfile also selected `trybuild` and `bytesize` releases requiring Rust 1.85, plus a target-only `wasip2` / `wit-bindgen` release line requiring Rust 1.87 and using edition 2024. The latter cannot be parsed by Cargo 1.81 even though it is not compiled for the host target.

The added versions are the latest compatible release lines identified with `cargo info` lookups.

## Validation

- `just test-no-coverage +1.97.1`
- `just test-msrv`
