### PR TITLE
ci: speed up Nix setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,13 @@ jobs:
         with:
           tool: just,nextest
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: workaround MSRV issues
         if: matrix.toolchain.name == 'msrv'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,16 +27,13 @@ jobs:
         with:
           tool: just,cargo-llvm-cov
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Generate code coverage
         run: just test-coverage-codecov

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,16 +32,13 @@ jobs:
         with:
           tool: just,cargo-hack
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci
 
       - name: Clippy
         run: just clippy

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
       perSystem = { pkgs, config, inputs', system, lib, ... }: {
         formatter = pkgs.nixpkgs-fmt;
 
+        devShells.ci = pkgs.mkShell {
+          shellHook = config.x52.justRust.shellHook;
+        };
+
         devShells.default = pkgs.mkShell {
           packages = [
             config.formatter


### PR DESCRIPTION
## Summary

- install upstream Nix with `nix-quick-install-action`
- remove the FlakeHub cache from Nix-backed CI jobs
- use a focused `.#ci` dev shell while keeping `nix-develop` as a separate step
- keep the full default development shell unchanged

## Why

A recent Blacksmith baseline showed that cache upload dominated otherwise short jobs:

| Job | Total | Install Nix | Cache setup | Enter dev shell | Main command | Cache post |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| stable tests | 3m41s | 4s | 6s | 18s | 13s | 2m40s |
| clippy | 4m00s | 4s | 6s | 19s | 42s | 2m12s |
| MSRV tests | 4m17s | 4s | 6s | 20s | 3m28s | 1s |

The CI shell retains the x52 Just shell hook, which generates `.toolchain/rust.just`, but does not add tools that the workflow already installs explicitly.

## Validation

- `nix develop .#ci -c just --list`
- `nix flake check --no-build --all-systems`

## Timing

One completed Blacksmith sample from commit `8752c67`:

| Job | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| stable tests | 3m41s | 37s | -3m04s (-83%) |
| clippy | 4m00s | 1m04s | -2m56s (-73%) |
| MSRV tests | 4m17s | 3m47s | -30s (-12%) |

In all three Nix-backed jobs, Nix installation took 0-1s and entering the focused dev shell took 7s. There is no cache post-step. The MSRV job remains workload-bound: its workaround and tests took 3m23s.

- [CI run](https://github.com/x52dev/confik/actions/runs/30727717193)
- [Lint run](https://github.com/x52dev/confik/actions/runs/30727707909)
