### PR TITLE
ci: use focused release devshell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,19 +33,15 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         id: release-plz
 
-      - name: Install Determinate Nix
+      - name: Install Nix
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
-        with:
-          extra-conf: lazy-trees = true
-
-      - name: Set up FlakeHub Cache
-        if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
-        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Enter Nix devshell
         if: ${{ steps.release-plz.outputs.prs_created == 'true' || steps.release-plz.outputs.releases_created == 'true' }}
         uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci-release
 
       - name: Bump changelog versions
         if: ${{ steps.release-plz.outputs.prs_created == 'true' }}

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,12 @@
           shellHook = config.x52.justRust.shellHook;
         };
 
+        devShells.ci-release = pkgs.mkShell {
+          packages = [
+            inputs'.x52.packages.x52-release-tools
+          ];
+        };
+
         devShells.default = pkgs.mkShell {
           packages = [
             config.formatter


### PR DESCRIPTION
## Summary

- add a `ci-release` devshell that exposes only the release tools
- use the pinned `nixbuild/nix-quick-install-action` v35 setup for the release path
- keep `nix-develop` as its own step and select `.#ci-release`

The focused shell avoids evaluating or installing developer-only tooling in the release job. The default shell remains unchanged for local development.

## Validation

- `nix develop .#ci-release -c sh -c 'command -v x52-bump-changelogs; command -v x52-update-release-notes'`
- `nix flake check --no-build --all-systems`
- `nix develop .#ci -c just --list`
