### PR TITLE
ci: fix zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: nix
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -54,7 +55,8 @@ jobs:
         if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: scripts/update-macro-pin '${{ steps.release-plz.outputs.pr }}'
+          RELEASE_PLZ_PR_JSON: ${{ steps.release-plz.outputs.pr }}
+        run: scripts/update-macro-pin "$RELEASE_PLZ_PR_JSON"
 
       - name: Update release notes
         if: ${{ steps.release-plz.outputs.releases_created == 'true' }}


### PR DESCRIPTION
Fixes the remaining zizmor findings:

- add a seven-day Dependabot cooldown for Actions, Nix, and Cargo updates;
- disable checkout credential persistence in coverage and release workflows;
- pass release-plz metadata through an environment variable before calling the pin-update script.

Validation:

- `zizmor v1.29.0 --offline /workspace` — no findings to report.